### PR TITLE
Replace base image with node alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:latest
+FROM node:current-alpine
 
 RUN npm i -g pnpm
 


### PR DESCRIPTION
 ## Summary
 
The original Docker image used full Node as the base image to build the project. That image size ended up being over 1GB big. This made start time slow on Heroku. To help reduce the size of the image, I replaced the base image with node-alpine which is a much more slimmed down version of the previous node image. This has reduced the image size to ~300MB.
 
 ## Changes
 
`Dockerfile` - Replaced node base image with node-alpine
