### PR TITLE
Alert when redirected from room

### DIFF
--- a/web/src/Layout.tsx
+++ b/web/src/Layout.tsx
@@ -9,7 +9,7 @@ type LobbyRouteStateType = {
 }
 
 type HomeRouteStateType = {
-  redirect: boolean | undefined;
+  invalidRoomCode: boolean | undefined;
 }
 
 type LobbyRouteParamsType = {
@@ -34,7 +34,7 @@ const Layout: React.FC = () => (
         path="/"
         render={({ location }: RouteComponentProps<LobbyRouteParamsType>) => (
           <Home
-            redirect={(location.state as HomeRouteStateType)?.redirect}
+            invalidRoomCode={(location.state as HomeRouteStateType)?.invalidRoomCode}
           />
         )}
       />

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -19,10 +19,10 @@ import useDocTitle from "../hooks/useDocTitle";
 import get from "../utils/get";
 
 interface ILobbyProps {
-  redirect: boolean | undefined;
+  invalidRoomCode: boolean | undefined;
 }
 
-const Home: React.FC<ILobbyProps> = ({ redirect }) => {
+const Home: React.FC<ILobbyProps> = ({ invalidRoomCode }) => {
   const history = useHistory();
   const toast = useToast();
   useDocTitle("Home");
@@ -52,7 +52,7 @@ const Home: React.FC<ILobbyProps> = ({ redirect }) => {
   }
 
   React.useEffect(() => {
-    if (redirect) {
+    if (invalidRoomCode) {
       toast({
         title: "The room you tried to join doesn't exist.",
         description: "Double check you have the correct room code, or start a new room.",
@@ -63,7 +63,7 @@ const Home: React.FC<ILobbyProps> = ({ redirect }) => {
       });
       history.push({
         state: {
-          redirect: undefined,
+          invalidRoomCode: undefined,
         },
       });
     }

--- a/web/src/pages/Lobby.tsx
+++ b/web/src/pages/Lobby.tsx
@@ -24,7 +24,7 @@ const Lobby: React.FC<ILobbyProps> = ({ newRoom, roomCode }) => {
         history.push({
           pathname: `/`,
           state: {
-            redirect: true,
+            invalidRoomCode: true,
           },
         });
       }


### PR DESCRIPTION
Reviewer: Matt
 
 ## Summary
 
 -- A brief summary of what all was changed --
Created state props to pass from Lobby to Home.
Mounting toast if you are redirected from an incorrect URL. 
 
 ## Changes

-------------------------------------Home-------------------------------------------------
Line 15
Imported useToast

lines 21-23
Created redirect prop for the state

line 27 
Using useToast as toast

lines 54 - 70
If you are redirected because of an incorrect room code in the URL then toast will launch. Then a new state is pushed for redirect so toast doesn't launch again unless you are redirected.

-------------------------------------Lobby-------------------------------------------------
lines 23 - 31
Changed the history.push to also push a redirect state of true

-------------------------------------Layout-------------------------------------------------
Passed in the redirect state to home. 