### PR TITLE
Action/exchange

### DIFF
--- a/web/src/GameState/GameStateMachine.ts
+++ b/web/src/GameState/GameStateMachine.ts
@@ -1,5 +1,6 @@
 import { assign, createMachine } from "xstate";
 import type { Actions, Influence } from "@contexts/GameStateContext";
+import type { IGameStateExchangeDetails } from "./types";
 
 export interface IGameStateMachineContextPlayerIds {
   blockerId: string;
@@ -17,6 +18,7 @@ export interface IGameStateMachineContextMetadata {
   blockingInfluence: Influence | undefined;
   challengeFailed: boolean | undefined;
   blockSuccessful: boolean | undefined;
+  exchangeDetails: IGameStateExchangeDetails | undefined;
 }
 
 export type IGameStateMachineContext = IGameStateMachineContextPlayerIds & IGameStateMachineContextMetadata;
@@ -30,7 +32,7 @@ export type GameStateMachineEvent =
   | { type: "END_GAME"; winningPlayerId: string }
   | { type: "FAILED" }
   | { type: "LOSE_INFLUENCE"; killedInfluence: Influence; challengeFailed: boolean }
-  | { type: "PASS"; killedInfluence: Influence | undefined }
+  | { type: "PASS"; killedInfluence: Influence | undefined; exchangeDetails: IGameStateExchangeDetails }
   | { type: "PLAY_AGAIN" }
   | { type: "START"; playerTurnId: string };
 
@@ -54,6 +56,7 @@ const GameStateMachine = createMachine<IGameStateMachineContext, GameStateMachin
     blockingInfluence: undefined,
     challengeFailed: undefined,
     challengerId: "",
+    exchangeDetails: undefined,
     gameStarted: false,
     killedInfluence: undefined,
     performerId: "",
@@ -170,6 +173,7 @@ const GameStateMachine = createMachine<IGameStateMachineContext, GameStateMachin
         blockingInfluence: undefined,
         challengeFailed: undefined,
         challengerId: "",
+        exchangeDetails: undefined,
         killedInfluence: undefined,
         performerId: "",
         victimId: "",
@@ -205,9 +209,10 @@ const GameStateMachine = createMachine<IGameStateMachineContext, GameStateMachin
           target: "idle",
         },
         PASS: {
-          actions: assign({
-            killedInfluence: (_, event) => event.killedInfluence,
-          }),
+          actions: assign((_, event) => ({
+            exchangeDetails: event.exchangeDetails,
+            killedInfluence: event.killedInfluence,
+          })),
         },
       },
     },

--- a/web/src/GameState/types.ts
+++ b/web/src/GameState/types.ts
@@ -1,4 +1,4 @@
-import type { IPlayer } from "@contexts/GameStateContext";
+import type { IPlayer, IPlayerInfluence } from "@contexts/GameStateContext";
 import type { State, SingleOrArray, SCXML, EventData, Event } from "xstate";
 import type { GameStateMachineEvent, GameStateMachineState, IGameStateMachineContext } from "./GameStateMachine";
 
@@ -17,4 +17,9 @@ export interface IGameStateRoles {
   performer: IPlayer | undefined;
   victim: IPlayer | undefined;
   winningPlayer: IPlayer | undefined;
+}
+
+export interface IGameStateExchangeDetails {
+  playerHand: Array<IPlayerInfluence>;
+  deck: Array<IPlayerInfluence>;
 }

--- a/web/src/GameState/useCurrentGameState/hooks/usePlayerActions.ts
+++ b/web/src/GameState/useCurrentGameState/hooks/usePlayerActions.ts
@@ -11,6 +11,7 @@ interface IUsePlayerActions {
   performAidAction: IPerformPlayerAction;
   performStealAction: IPerformPlayerAction;
   performAssassinateAction: IPerformPlayerAction;
+  performExchangeAction: IPerformPlayerAction;
 }
 
 export default function usePlayerActions(
@@ -154,10 +155,25 @@ export default function usePlayerActions(
     return newPlayers.map((player) => ({ ...player, actionResponse: null }));
   }
 
+  function ExchangeAction(players: Array<IPlayer>): Array<IPlayer> {
+    if (!performer) throw new PlayerNotFoundError(gameStateContext.performerId);
+    if (!gameStateContext.exchangeDetails) throw new Error("No exchange details when performing exchange.");
+
+    const newPlayers = [...players];
+
+    newPlayers[performer.index] = {
+      ...newPlayers[performer.index],
+      influences: [...gameStateContext.exchangeDetails.playerHand],
+    };
+
+    return newPlayers;
+  }
+
   return {
     performAidAction: AidAction,
     performAssassinateAction: AssassinateAction,
     performCoupAction: CoupAction,
+    performExchangeAction: ExchangeAction,
     performIncomeAction: IncomeAction,
     performStealAction: StealAction,
     performTaxAction: TaxAction,

--- a/web/src/GameState/useCurrentGameState/hooks/useProcessPerformAction.ts
+++ b/web/src/GameState/useCurrentGameState/hooks/useProcessPerformAction.ts
@@ -99,7 +99,8 @@ export default function useProcessPerformAction(
           break;
         }
         case Actions.Exchange: {
-          if (gameStateContext.exchangeDetails) {
+          const { exchangeDetails } = gameStateContext;
+          if (exchangeDetails) {
             setPlayers((prevPlayers) => performExchangeAction(prevPlayers));
 
             setDeck((prevDeck) => {
@@ -109,7 +110,7 @@ export default function useProcessPerformAction(
               newDeck.splice(0, 2);
 
               // add the deck cards to the back of the deck
-              gameStateContext.exchangeDetails?.deck.forEach((playerInfluence) => {
+              exchangeDetails.deck.forEach((playerInfluence) => {
                 newDeck.push(playerInfluence.type);
               });
               return newDeck;

--- a/web/src/GameState/useCurrentGameState/hooks/useProcessProposeAction.ts
+++ b/web/src/GameState/useCurrentGameState/hooks/useProcessProposeAction.ts
@@ -20,6 +20,7 @@ export default function useProcessProposeAction(
           break;
         case Actions.Aid:
         case Actions.Assassinate:
+        case Actions.Exchange:
         case Actions.Steal:
         case Actions.Tax:
           // the performer isn't going to challenge themselves so automatically set their response to PASS

--- a/web/src/components/Actions/components/ActionButtons.tsx
+++ b/web/src/components/Actions/components/ActionButtons.tsx
@@ -4,7 +4,7 @@ import { Actions } from "@contexts/GameStateContext";
 import { InfluenceDetails } from "@utils/InfluenceUtils";
 
 interface IWrappedButtonProps extends Omit<ButtonProps, "width"> {
-  action?: Actions;
+  action: Actions;
 }
 
 interface IActionButtonsProps extends WrapProps {
@@ -22,10 +22,8 @@ const ActionButtons: React.FC<IActionButtonsProps> = ({
   const WrappedButton: React.FC<IWrappedButtonProps> = ({ action, children, disabled, ...buttonProps }) => (
     <WrapItem>
       <Button
-        // every button will eventually have an actionPayload or onClick.
-        // this is temporary to prevent a tester from crashing the app.
-        disabled={!isTurn || !action || disabled}
-        onClick={() => action ? onAction(action) : null}
+        disabled={!isTurn || disabled}
+        onClick={() => !disabled ? onAction(action) : null}
         width="130px"
         {...buttonProps}
       >
@@ -57,7 +55,11 @@ const ActionButtons: React.FC<IActionButtonsProps> = ({
       >
         Assassinate
       </WrappedButton>
-      <WrappedButton colorScheme={InfluenceDetails["Ambassador"].colorScheme} disabled={coinCount >= 10}>
+      <WrappedButton
+        action={Actions.Exchange}
+        colorScheme={InfluenceDetails["Ambassador"].colorScheme}
+        disabled={coinCount >= 10}
+      >
         Exchange
       </WrappedButton>
       <WrappedButton
@@ -75,7 +77,7 @@ const ActionButtons: React.FC<IActionButtonsProps> = ({
         Foreign Aid
       </WrappedButton>
       <WrappedButton
-        action={coinCount >= 7 ? Actions.Coup : undefined}
+        action={Actions.Coup}
         colorScheme="red"
         disabled={coinCount < 7}
       >

--- a/web/src/components/GameModalChooser/GameModalChooser.tsx
+++ b/web/src/components/GameModalChooser/GameModalChooser.tsx
@@ -11,6 +11,7 @@ const GameModalChooser: React.FC = () => {
     currentStateMatches,
     challenger,
     currentPlayer,
+    exchangeDetails,
     performer,
     victim,
     winningPlayer,
@@ -60,6 +61,7 @@ const GameModalChooser: React.FC = () => {
           blockDetails={{ blocker, blockingInfluence }}
           currentPlayer={currentPlayer}
           currentStateMatches={currentStateMatches}
+          exchangeDetails={exchangeDetails}
           handleActionResponse={handleActionResponse}
           handleGameEvent={handleGameEvent}
           killedInfluence={killedInfluence}

--- a/web/src/components/InfluenceCard.tsx
+++ b/web/src/components/InfluenceCard.tsx
@@ -1,11 +1,13 @@
 import * as React from "react";
-import { Box, Image, ImageProps, keyframes, useToken } from "@chakra-ui/react";
+import { Box, BoxProps, Image, ImageProps, keyframes, useToken } from "@chakra-ui/react";
 import type { Influence } from "@contexts/GameStateContext/types";
 import { InfluenceDetails } from "@utils/InfluenceUtils";
 import { BlankImg } from "@images/InfluenceImages";
 import { DeathIcon } from "@icons";
 
-interface IInfluenceCardProps extends ImageProps {
+export interface IInfluenceCardProps extends ImageProps {
+  containerProps?: Partial<BoxProps>;
+  disableAnimation?: boolean;
   faceUp: boolean;
   enlarge?: boolean;
   influence: Influence;
@@ -34,9 +36,11 @@ const growIn = keyframes({
 });
 
 const InfluenceCard: React.FC<IInfluenceCardProps> = ({
+  containerProps,
   influence,
   faceUp,
   onClick,
+  disableAnimation = false,
   enlarge = false,
   isDead = false,
   ...props 
@@ -44,7 +48,7 @@ const InfluenceCard: React.FC<IInfluenceCardProps> = ({
   const [iconWidthSm, iconWidthEnlarge] = useToken("sizes", ["24", "28"]);
 
   return (
-    <Box position="relative">
+    <Box position="relative" {...containerProps}>
       <Image
         alt={faceUp || isDead ? `Dead ${influence}` : "Hidden Influence"}
         src={faceUp || isDead ? InfluenceDetails[influence].img : BlankImg}
@@ -56,13 +60,19 @@ const InfluenceCard: React.FC<IInfluenceCardProps> = ({
       {isDead && (
         <Box
           position="absolute"
-          top="0"
-          left="0"
-          width="100%"
-          height="100%"
-          animation={`${fadeIn} 1s ease-in forwards`}
+          inset={containerProps?.padding ?? 0}
+          animation={disableAnimation ? "" : `${fadeIn} 1s ease-in`}
+          backgroundColor="rgba(0, 0, 0, 0.5)"
+          borderRadius="3px"
         >
-          <Box animation={`${growIn} 2.5s ease-in forwards`} marginX="auto" marginTop="2" width="min" opacity="0">
+          <Box
+            animation={disableAnimation ? "" : `${growIn} 2.5s ease-in`}
+            opacity={1}
+            transform="scale(1)"
+            marginX="auto"
+            marginTop="2"
+            width="min"
+          >
             <DeathIcon
               color="rgba(255, 255, 255, 0.6)"
               width={enlarge ? iconWidthEnlarge : iconWidthSm}

--- a/web/src/components/Modals/ExchangeModal.tsx
+++ b/web/src/components/Modals/ExchangeModal.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Button, Divider, HStack, Text, useToken, VStack } from "@chakra-ui/react";
+import { BoxProps, Button, Divider, HStack, Text, VStack } from "@chakra-ui/react";
 import type { IPlayer, IPlayerInfluence } from "@contexts/GameStateContext/types";
 import InfluenceCard from "../InfluenceCard";
 import BaseModal from "./BaseModal";
@@ -15,7 +15,6 @@ interface IExchangeCard extends IPlayerInfluence {
 }
 
 const ExchangeModal: React.FC<IExchangeModal> = ({ currentPlayer, handleClose }) => {
-  const blueBorder = useToken("colors", "blue.300");
   const { deck } = useDeck();
 
   const [deckCards, setDeckCards] = React.useState<Array<IExchangeCard>>(
@@ -65,6 +64,16 @@ const ExchangeModal: React.FC<IExchangeModal> = ({ currentPlayer, handleClose })
     handleClose(newPlayersHand, newDeckCards);
   }
 
+  const commonInfluenceCardContainerProps: BoxProps = {
+    _selected: {
+      borderColor: "teal.200",
+    },
+    border: "4px solid transparent",
+    borderRadius: "8px",
+    padding: "1",
+    transition: "transform 500ms",
+  };
+
   return (
     <BaseModal>
       <VStack spacing="4" margin="5">
@@ -84,28 +93,28 @@ const ExchangeModal: React.FC<IExchangeModal> = ({ currentPlayer, handleClose })
             {deckCards
               .map((exchangeInfluence, index) => (
                 <InfluenceCard
-                  aria-selected={exchangeInfluence.key === selectedDeckCard?.key}
+                  containerProps={{
+                    _hover: {
+                      transform: `scale(1.05) translateX(${index === 0 ? "-5px" : "5px"})`,
+                    },
+                    "aria-selected": exchangeInfluence.key === selectedDeckCard?.key,
+                    onClick: () => setSelectedDeckCard((prevSelectedDeckCard) => (
+                      prevSelectedDeckCard?.key === exchangeInfluence.key ? null : exchangeInfluence
+                    )),
+                    role: "button",
+                    ...commonInfluenceCardContainerProps,
+                  }}
                   key={exchangeInfluence.key}
+                  influence={exchangeInfluence.type}
                   enlarge
                   faceUp
-                  onClick={() => setSelectedDeckCard((prevSelectedDeckCard) => (
-                    prevSelectedDeckCard?.key === exchangeInfluence.key ? null : exchangeInfluence
-                  ))}
-                  influence={exchangeInfluence.type}
-                  _hover={{
-                    transform: `scale(1.05) translateX(${index === 0 ? "-5px" : "5px"})`,
-                  }}
-                  _selected={{
-                    boxShadow: `0px 0px 0px 3px ${blueBorder}`
-                  }}
-                  transition="transform 500ms"
-                  role="button"
+                  disableAnimation
                 />
               ))}
           </HStack>
         </VStack>
         <VStack>
-          <HStack justifyContent="space-between" width="100%">
+          <HStack justifyContent="space-between" width="full">
             <Text flex="1">Your Hand</Text>
             <Text textAlign="right" color="gray.400">Cards you&apos;ll keep.</Text>
           </HStack>
@@ -113,23 +122,23 @@ const ExchangeModal: React.FC<IExchangeModal> = ({ currentPlayer, handleClose })
             {playerCards
               .map((exchangeInfluence, index) => (
                 <InfluenceCard
-                  aria-selected={exchangeInfluence.key === selectedPlayerCard?.key}
+                  containerProps={{
+                    _hover: exchangeInfluence.isDead ? {} : {
+                      transform: `scale(1.05) translateX(${index === 0 ? "-5px" : "5px"})`,
+                    },
+                    "aria-selected": exchangeInfluence.key === selectedPlayerCard?.key,
+                    onClick: !exchangeInfluence.isDead ? () => setSelectedPlayerCard((prevSelectedPlayerCard) => (
+                      prevSelectedPlayerCard?.key === exchangeInfluence.key ? null : exchangeInfluence
+                    )) : undefined,
+                    role: exchangeInfluence.isDead ? "" : "button",
+                    ...commonInfluenceCardContainerProps,
+                  }}
                   key={exchangeInfluence.key}
-                  enlarge
-                  faceUp
-                  onClick={() => setSelectedPlayerCard((prevSelectedPlayerCard) => (
-                    prevSelectedPlayerCard?.key === exchangeInfluence.key ? null : exchangeInfluence
-                  ))}
                   isDead={exchangeInfluence.isDead}
                   influence={exchangeInfluence.type}
-                  _hover={ exchangeInfluence.isDead ? {} : {
-                    transform: `scale(1.05) translateX(${index === 0 ? "-5px" : "5px"})`,
-                  }}
-                  _selected={{
-                    boxShadow: `0px 0px 0px 3px ${blueBorder}`
-                  }}
-                  transition="transform 500ms"
-                  role={exchangeInfluence.isDead ? "" : "button"}
+                  enlarge
+                  faceUp
+                  disableAnimation
                 />
               ))}
           </HStack>

--- a/web/src/components/Modals/ExchangeModal.tsx
+++ b/web/src/components/Modals/ExchangeModal.tsx
@@ -1,0 +1,146 @@
+import * as React from "react";
+import { Button, Divider, HStack, Text, useToken, VStack } from "@chakra-ui/react";
+import type { IPlayer, IPlayerInfluence } from "@contexts/GameStateContext/types";
+import InfluenceCard from "../InfluenceCard";
+import BaseModal from "./BaseModal";
+import { useDeck } from "@contexts/DeckContext";
+
+interface IExchangeModal {
+  handleClose: (playerHand: Array<IPlayerInfluence>, deck: Array<IPlayerInfluence>) => void;
+  currentPlayer: IPlayer;
+}
+
+interface IExchangeCard extends IPlayerInfluence {
+  key: string;
+}
+
+const ExchangeModal: React.FC<IExchangeModal> = ({ currentPlayer, handleClose }) => {
+  const blueBorder = useToken("colors", "blue.300");
+  const { deck } = useDeck();
+
+  const [deckCards, setDeckCards] = React.useState<Array<IExchangeCard>>(
+    deck.slice(0, 2).map((influence) => ({ isDead: false, key: `${influence}-${Math.random()}`, type: influence }))
+  );
+  const [playerCards, setPlayerCards] = React.useState<Array<IExchangeCard>>(
+    currentPlayer.influences.map(
+      (playerInfluence) => ({ ...playerInfluence, key: `${playerInfluence.type}-${Math.random()}` })
+    )
+  );
+ 
+  const [selectedDeckCard, setSelectedDeckCard] = React.useState<IExchangeCard | null>();
+  const [selectedPlayerCard, setSelectedPlayerCard] = React.useState<IExchangeCard | null>();
+
+  React.useEffect(() => {
+    if (selectedDeckCard && selectedPlayerCard) {
+      setPlayerCards((prevPlayerCards) => (
+        prevPlayerCards.map((prevPlayerCard) => {
+          if (prevPlayerCard.key === selectedPlayerCard.key) {
+            return selectedDeckCard;
+          } else {
+            return prevPlayerCard;
+          }
+        })
+      ));
+      setDeckCards((prevDeckCards) => (
+        prevDeckCards.map((prevDeckCard) => {
+          if (prevDeckCard.key === selectedDeckCard.key) {
+            return selectedPlayerCard;
+          } else {
+            return prevDeckCard;
+          }
+        })
+      ));
+      setSelectedDeckCard(null);
+      setSelectedPlayerCard(null);
+    }
+  }, [selectedDeckCard, selectedPlayerCard]);
+
+  function handleDone() {
+    const newPlayersHand: Array<IPlayerInfluence> = playerCards.map(
+      (playerCard) => ({ isDead: playerCard.isDead, type: playerCard.type })
+    );
+    const newDeckCards: Array<IPlayerInfluence> = deckCards.map(
+      (deckCard) => ({ isDead: false, type: deckCard.type })
+    );
+    handleClose(newPlayersHand, newDeckCards);
+  }
+
+  return (
+    <BaseModal>
+      <VStack spacing="4" margin="5">
+        <Text fontSize="large" textAlign="center">
+          Select one card from the deck and one from your hand to swap.
+        </Text>
+        <Text fontSize="large" textAlign="center">
+          Once you are happy with your hand, click <Text as="span" fontWeight="bold">Done</Text>.
+        </Text>
+        <Divider />
+        <VStack>
+          <HStack justifyContent="space-between" width="full">
+            <Text flex="1">Deck</Text>
+            <Text textAlign="right" color="gray.400">Cards to go back in the deck.</Text>
+          </HStack>
+          <HStack spacing="10px">
+            {deckCards
+              .map((exchangeInfluence, index) => (
+                <InfluenceCard
+                  aria-selected={exchangeInfluence.key === selectedDeckCard?.key}
+                  key={exchangeInfluence.key}
+                  enlarge
+                  faceUp
+                  onClick={() => setSelectedDeckCard((prevSelectedDeckCard) => (
+                    prevSelectedDeckCard?.key === exchangeInfluence.key ? null : exchangeInfluence
+                  ))}
+                  influence={exchangeInfluence.type}
+                  _hover={{
+                    transform: `scale(1.05) translateX(${index === 0 ? "-5px" : "5px"})`,
+                  }}
+                  _selected={{
+                    boxShadow: `0px 0px 0px 3px ${blueBorder}`
+                  }}
+                  transition="transform 500ms"
+                  role="button"
+                />
+              ))}
+          </HStack>
+        </VStack>
+        <VStack>
+          <HStack justifyContent="space-between" width="100%">
+            <Text flex="1">Your Hand</Text>
+            <Text textAlign="right" color="gray.400">Cards you&apos;ll keep.</Text>
+          </HStack>
+          <HStack spacing="10px">
+            {playerCards
+              .map((exchangeInfluence, index) => (
+                <InfluenceCard
+                  aria-selected={exchangeInfluence.key === selectedPlayerCard?.key}
+                  key={exchangeInfluence.key}
+                  enlarge
+                  faceUp
+                  onClick={() => setSelectedPlayerCard((prevSelectedPlayerCard) => (
+                    prevSelectedPlayerCard?.key === exchangeInfluence.key ? null : exchangeInfluence
+                  ))}
+                  isDead={exchangeInfluence.isDead}
+                  influence={exchangeInfluence.type}
+                  _hover={ exchangeInfluence.isDead ? {} : {
+                    transform: `scale(1.05) translateX(${index === 0 ? "-5px" : "5px"})`,
+                  }}
+                  _selected={{
+                    boxShadow: `0px 0px 0px 3px ${blueBorder}`
+                  }}
+                  transition="transform 500ms"
+                  role={exchangeInfluence.isDead ? "" : "button"}
+                />
+              ))}
+          </HStack>
+        </VStack>
+        <Divider />
+        <Button onClick={() => handleDone()} width="full" height="12">
+          Done
+        </Button>
+      </VStack>
+    </BaseModal>
+  );
+};
+
+export default ExchangeModal;

--- a/web/src/contexts/GameStateContext/GameStateContext.tsx
+++ b/web/src/contexts/GameStateContext/GameStateContext.tsx
@@ -167,6 +167,7 @@ export const GameStateContextProvider: React.FC = ({ children }) => {
         challengeFailed: currentGameState.context.challengeFailed,
         currentPlayer,
         currentStateMatches: currentGameState.matches,
+        exchangeDetails: currentGameState.context.exchangeDetails,
         gameStarted: currentGameState.context.gameStarted,
         handleActionResponse,
         handleGameEvent,

--- a/web/src/hooks/useActionToast.tsx
+++ b/web/src/hooks/useActionToast.tsx
@@ -49,6 +49,8 @@ const ActionToast: React.FC<IActionToastProps> = ({
         {/* TODO: Needs Graphic */}
         {variant === Actions.Steal && <CoinIcon width={iconSize} />}
         {variant === Actions.Assassinate && <AssassinIcon width={iconSize} />}
+        {/* TODO: Needs Graphic */}
+        {variant === Actions.Exchange && <CoinIcon width={iconSize} />}
       </Center>
       <Box fontSize="large">
         {variant === Actions.Income && (
@@ -138,6 +140,14 @@ const ActionToast: React.FC<IActionToastProps> = ({
               {lostInfluence}
             </Text>
             !
+          </Text>
+        )}
+        {variant === Actions.Exchange && (
+          <Text>
+            <Text as="span" fontWeight="bold">
+              {performerName}
+            </Text>
+            {" exchanged their cards. No one likes double Contessas."}
           </Text>
         )}
         {variant === "Challenge" && (


### PR DESCRIPTION
## Summary

Added the Ambassador exchange action. The Ambassador pulls two cards from the deck and may exchange any card. The action cannot be blocked.

## Changes

`GameStateMachine.ts` - Added `exchangeDetails` for tracking the deck and player hand cards.
`usePlayerActions.ts` - Add exchange action.
`useProcessPerformAction.ts` - Add exchange action.
`useProcessProposeAction.ts` - Add exchange action.
`ActionButtons.tsx` - Add exchange action and remove extra disabled checks since all actions are implemented.
`GameModalChooser.tsx` - Add exchange details.
`ActionModalChooser.tsx` - Add exchange modal.
`InfluenceCard.tsx` - Add extra props for styling cards in ExchangeModal.
`ExchangeModal.tsx` - Modal for exchanging cards.
`GameStateContext.tsx` - Add exchangeDetails
`useActionToast` - Add exchange action.