### PR TITLE
Handle assassination when victim has no cards left alive

### DIFF
--- a/web/src/GameState/GameStateMachine.ts
+++ b/web/src/GameState/GameStateMachine.ts
@@ -14,7 +14,7 @@ export interface IGameStateMachineContextPlayerIds {
 export interface IGameStateMachineContextMetadata {
   action: Actions | null;
   gameStarted: boolean;
-  killedInfluence: Influence | undefined;
+  killedInfluence: Influence | "NO_INFLUENCES_LEFT" | undefined;
   blockingInfluence: Influence | undefined;
   challengeFailed: boolean | undefined;
   blockSuccessful: boolean | undefined;
@@ -32,7 +32,11 @@ export type GameStateMachineEvent =
   | { type: "END_GAME"; winningPlayerId: string }
   | { type: "FAILED" }
   | { type: "LOSE_INFLUENCE"; killedInfluence: Influence; challengeFailed: boolean }
-  | { type: "PASS"; killedInfluence: Influence | undefined; exchangeDetails: IGameStateExchangeDetails }
+  | {
+      type: "PASS";
+      killedInfluence: Influence | "NO_INFLUENCES_LEFT" | undefined;
+      exchangeDetails: IGameStateExchangeDetails;
+    }
   | { type: "PLAY_AGAIN" }
   | { type: "START"; playerTurnId: string };
 

--- a/web/src/GameState/useCurrentGameState/hooks/useProcessChallenge.ts
+++ b/web/src/GameState/useCurrentGameState/hooks/useProcessChallenge.ts
@@ -24,6 +24,11 @@ export default function useProcessChallenge(
       if (!performer) throw new Error("No performer found when processing challenge.");
       if (!challenger) throw new Error("No challenger found when processing challenge.");
 
+      const killedInfluence = gameStateContext.killedInfluence;
+      if (killedInfluence === "NO_INFLUENCES_LEFT") {
+        throw new Error("Tried to use NO_INFLUENCES_LEFT during a challenge which is not allowed.");
+      }
+
       const loser = gameStateContext.challengeFailed ? challenger : performer;
       const winner = gameStateContext.challengeFailed ? performer : challenger;
 
@@ -31,7 +36,7 @@ export default function useProcessChallenge(
       const newDeck: Array<Influence> = [...deck];
 
       const influenceToKillIndex = newPlayers[loser.index].influences.findIndex(
-        (influence) => influence.type === gameStateContext.killedInfluence && !influence.isDead,
+        (influence) => influence.type === killedInfluence && !influence.isDead,
       );
 
       // victim's chosen influence to kill
@@ -80,7 +85,7 @@ export default function useProcessChallenge(
       setPlayers(newPlayers);
       setDeck(newDeck);
       actionToast({
-        lostInfluence: gameStateContext.killedInfluence,
+        lostInfluence: killedInfluence,
         variant: "Challenge" as const,
         victimName: loser.name,
       });
@@ -95,6 +100,11 @@ export default function useProcessChallenge(
       if (!blocker) throw new Error("No blocker found when processing challenge.");
       if (!challenger) throw new Error("No challenger found when processing challenge.");
 
+      const killedInfluence = gameStateContext.killedInfluence;
+      if (killedInfluence === "NO_INFLUENCES_LEFT") {
+        throw new Error("Tried to use NO_INFLUENCES_LEFT during a challenge which is not allowed.");
+      }
+
       const loser = gameStateContext.challengeFailed ? challenger : blocker;
       const winner = gameStateContext.challengeFailed ? blocker : challenger;
 
@@ -102,7 +112,7 @@ export default function useProcessChallenge(
       const newDeck = [...deck];
 
       const influenceToKillIndex = newPlayers[loser.index].influences.findIndex(
-        (influence) => influence.type === gameStateContext.killedInfluence && !influence.isDead,
+        (influence) => influence.type === killedInfluence && !influence.isDead,
       );
 
       // victim's chosen influence to kill
@@ -149,7 +159,7 @@ export default function useProcessChallenge(
       setPlayers(newPlayers);
       setDeck(newDeck);
       actionToast({
-        lostInfluence: gameStateContext.killedInfluence,
+        lostInfluence: killedInfluence,
         variant: "Challenge",
         victimName: loser.name,
       });

--- a/web/src/GameState/useCurrentGameState/hooks/useProcessPerformAction.ts
+++ b/web/src/GameState/useCurrentGameState/hooks/useProcessPerformAction.ts
@@ -38,6 +38,9 @@ export default function useProcessPerformAction(
             setPlayers((prevPlayers) => performCoupAction(prevPlayers));
 
             if (!victim) throw new Error("No victim found when performing Coup.");
+            if (gameStateContext.killedInfluence === "NO_INFLUENCES_LEFT") {
+              throw new Error("Tried to coup using NO_INFLUENCES_LEFT which is not allowed.");
+            }
 
             return {
               lostInfluence: gameStateContext.killedInfluence,
@@ -89,8 +92,11 @@ export default function useProcessPerformAction(
 
             if (!victim) throw new Error("No victim found when performing assassination.");
 
+            const lostInfluence =
+              gameStateContext.killedInfluence !== "NO_INFLUENCES_LEFT" ? gameStateContext.killedInfluence : undefined;
+
             return {
-              lostInfluence: gameStateContext.killedInfluence,
+              lostInfluence,
               performerName: performer.name,
               variant: Actions.Assassinate,
               victimName: victim.name,

--- a/web/src/components/GameModalChooser/ModalChoosers/ActionModalChooser.tsx
+++ b/web/src/components/GameModalChooser/ModalChoosers/ActionModalChooser.tsx
@@ -1,5 +1,4 @@
 import { Actions, IActionResponse, IGameState, Influence, IPlayer } from "@contexts/GameStateContext";
-import { usePlayers } from "@contexts/PlayersContext";
 import type { GameStateMachineStateOptions } from "@GameState/GameStateMachine";
 import type { IGameStateExchangeDetails } from "@GameState/types";
 import * as React from "react";
@@ -15,7 +14,7 @@ interface IActionModalChooserProps {
   exchangeDetails: IGameStateExchangeDetails | undefined;
   victim: IPlayer | undefined;
   currentStateMatches: (state: GameStateMachineStateOptions) => boolean;
-  killedInfluence: Influence | undefined;
+  killedInfluence: Influence | "NO_INFLUENCES_LEFT" | undefined;
   blockDetails: { blocker: IPlayer | undefined, blockingInfluence: Influence | undefined };
   handleGameEvent: (newGameState: IGameState) => void;
   handleActionResponse: (response: IActionResponse) => void;
@@ -34,7 +33,6 @@ const ActionModalChooser: React.FC<IActionModalChooserProps> = ({
   handleActionResponse,
 }) => {
   const { blocker, blockingInfluence } = blockDetails;
-  const { getNextPlayerTurnId } = usePlayers();
 
   if (
     currentStateMatches("perform_action")
@@ -74,8 +72,8 @@ const ActionModalChooser: React.FC<IActionModalChooserProps> = ({
     // processing the assassination. If that happens, just complete the action and move on.
     if (victimAliveInfluences.length === 0) {
       handleGameEvent({
-        event: "COMPLETE",
-        eventPayload: { nextPlayerTurnId: getNextPlayerTurnId(currentPlayer.id) },
+        event: "PASS",
+        eventPayload: { killedInfluence: "NO_INFLUENCES_LEFT" },
       });
 
       return <></>;

--- a/web/src/components/GameModalChooser/ModalChoosers/ChallengerModalChooser.tsx
+++ b/web/src/components/GameModalChooser/ModalChoosers/ChallengerModalChooser.tsx
@@ -73,13 +73,11 @@ const ChallengerModalChooser: React.FC<IChallengerModalChooserProps> = ({
     } else {
       // if current player is not the one choosing an influence to lose
       const success = challengeResult === "success";
-      const playerBeingChallenged = blocker?.name ?? performer.name;
-
       return (
         <WaitingForActionModal
           messaging={[
-            `${challenger.name}'s challenge against ${playerBeingChallenged} ${success ? "was successful" : "failed"}.`,
-            `Waiting for ${success ? playerBeingChallenged : challenger.name} to choose an Influence to lose.`,
+            `${challenger.name}'s challenge against ${performer.name} ${success ? "was successful" : "failed"}.`,
+            `Waiting for ${success ? performer.name : challenger.name} to choose an Influence to lose.`,
           ]}
         />
       );

--- a/web/src/components/GameModalChooser/ModalChoosers/ChallengerModalChooser.tsx
+++ b/web/src/components/GameModalChooser/ModalChoosers/ChallengerModalChooser.tsx
@@ -73,11 +73,13 @@ const ChallengerModalChooser: React.FC<IChallengerModalChooserProps> = ({
     } else {
       // if current player is not the one choosing an influence to lose
       const success = challengeResult === "success";
+      const playerBeingChallenged = blocker?.name ?? performer.name;
+
       return (
         <WaitingForActionModal
           messaging={[
-            `${challenger.name}'s challenge against ${performer.name} ${success ? "was successful" : "failed"}.`,
-            `Waiting for ${success ? performer.name : challenger.name} to choose an Influence to lose.`,
+            `${challenger.name}'s challenge against ${playerBeingChallenged} ${success ? "was successful" : "failed"}.`,
+            `Waiting for ${success ? playerBeingChallenged : challenger.name} to choose an Influence to lose.`,
           ]}
         />
       );

--- a/web/src/hooks/useActionToast.tsx
+++ b/web/src/hooks/useActionToast.tsx
@@ -134,11 +134,14 @@ const ActionToast: React.FC<IActionToastProps> = ({
             <Text as="span" fontWeight="bold">
               {victimName}
             </Text>
-            {" who lost their "}
-            {/* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */}
-            <Text as="span" fontWeight="bold" color={InfluenceDetails[lostInfluence!].color}>
-              {lostInfluence}
-            </Text>
+            {lostInfluence && (
+              <>
+                {" who lost their "}
+                <Text as="span" fontWeight="bold" color={InfluenceDetails[lostInfluence].color}>
+                  {lostInfluence}
+                </Text>
+              </>
+            )}
             !
           </Text>
         )}


### PR DESCRIPTION
## Summary

Before:
1. Player A with an Assassin assassinates Player B
2. Player B with only one card left alive challenges Player A
3. The challenge fails
4. Player B loses their last card due to the failed challenge
5. Player A doesn't lose 3 coins and the turn is not updated. <- BUG

Now:
1. Player A with an Assassin assassinates Player B
2. Player B with only one card left alive challenges Player A
3. The challenge fails
4. Player B loses their last card due to the failed challenge
5. Player A loses 3 coins and the turn is updated

## Changes

`GameStateMachine.ts` - Added new "NO_INFLUENCES_LEFT" constant for `killedInfluence`. This value should only be used when the victim of an assassination lost their final card during the action (failed challenge).
`useProcessChallenge.ts` - Error checking for new constant since it should never be an option during a challenge.
`useProcessPerformAction.ts` - Error checking for Coup (similar to challenge ^), and treat `killedInfluence` as `undefined` when it uses the new constant for assassinations when calling action toast.
`ActionModalChooser.tsx` - Pass new constant as killed influence when victim has no influences left alive during `perform_action` phase.
`useActionToast.tsx` - Handle `lostInfluence` being undefined during an assassination due to the changes to `useProcessPerformAction.ts`.
