### PR TITLE
Prevent stealing from players with 0 coins and only steal what the vi…

### DIFF
--- a/web/src/GameState/useCurrentGameState/hooks/usePlayerActions.ts
+++ b/web/src/GameState/useCurrentGameState/hooks/usePlayerActions.ts
@@ -107,16 +107,19 @@ export default function usePlayerActions(
       actionResponse: null,
     }));
 
+    // if victim has less than 2 coins, you can only take what they have
+    const coinsToSteal = Math.min(victim.coins, 2);
+
     // performer gains 2 coins
     newPlayers[performer.index] = {
       ...newPlayers[performer.index],
-      coins: newPlayers[performer.index].coins + 2,
+      coins: newPlayers[performer.index].coins + coinsToSteal,
     };
 
     // victim loses 2 coins
     newPlayers[victim.index] = {
       ...newPlayers[victim.index],
-      coins: newPlayers[victim.index].coins - 2,
+      coins: newPlayers[victim.index].coins - coinsToSteal,
     };
 
     return newPlayers;

--- a/web/src/components/Actions/components/PlayerSelect.tsx
+++ b/web/src/components/Actions/components/PlayerSelect.tsx
@@ -12,16 +12,21 @@ const PlayerSelect: React.FC<IPlayerSelectProps> = ({ players, onSelection, ...p
     {players.map((p) => (
       <ListItem
         key={p.id}
-        onClick={() => onSelection(p.id)}
+        onClick={() => p.coins > 0 ? onSelection(p.id) : null}
+        aria-disabled={p.coins === 0}
         height={280 / players.length}
         alignItems="center"
         display="flex"
         placeContent="center"
         role="button"
         transition="background 500ms"
-        _hover={{
-          background: "rgba(66, 153, 225, 0.6)",
+        _disabled={{
+          color: "whiteAlpha.500",
+          pointerEvents: "none"
         }}
+        _hover={ p.coins > 0 ? {
+          background: "rgba(66, 153, 225, 0.6)",
+        } : {}}
         sx={{
           "&:first-of-type": {
             borderRadius: "10px 10px 0px 0px",
@@ -35,7 +40,7 @@ const PlayerSelect: React.FC<IPlayerSelectProps> = ({ players, onSelection, ...p
           },
         }}
       >
-        <Text>{p.name}</Text>
+        <Text>{`${p.name} ${p.coins === 0 ? "(No coins to steal)" : ""}`}</Text>
       </ListItem>
     ))}
   </List>

--- a/web/src/components/Actions/components/PlayerSelect.tsx
+++ b/web/src/components/Actions/components/PlayerSelect.tsx
@@ -4,45 +4,50 @@ import type { IPlayer } from "@contexts/GameStateContext";
 
 interface IPlayerSelectProps extends ListProps {
   players: Array<IPlayer>;
+  isPlayerSelectable: (player: IPlayer) => boolean;
   onSelection: (selectedPlayerId: string) => void;
 }
 
-const PlayerSelect: React.FC<IPlayerSelectProps> = ({ players, onSelection, ...props }) => (
+const PlayerSelect: React.FC<IPlayerSelectProps> = ({ players, isPlayerSelectable, onSelection, ...props }) => (
   <List {...props}>
-    {players.map((p) => (
-      <ListItem
-        key={p.id}
-        onClick={() => p.coins > 0 ? onSelection(p.id) : null}
-        aria-disabled={p.coins === 0}
-        height={280 / players.length}
-        alignItems="center"
-        display="flex"
-        placeContent="center"
-        role="button"
-        transition="background 500ms"
-        _disabled={{
-          color: "whiteAlpha.500",
-          pointerEvents: "none"
-        }}
-        _hover={ p.coins > 0 ? {
-          background: "rgba(66, 153, 225, 0.6)",
-        } : {}}
-        sx={{
-          "&:first-of-type": {
-            borderRadius: "10px 10px 0px 0px",
-          },
-          "&:last-of-type": {
-            borderRadius: "0px 0px 10px 10px",
-          },
-          "&:not(:last-child)": {
-            borderBottom: "1px solid",
-            borderColor: "gray.800",
-          },
-        }}
-      >
-        <Text>{`${p.name} ${p.coins === 0 ? "(No coins to steal)" : ""}`}</Text>
-      </ListItem>
-    ))}
+    {players.map((p) => {
+      const playerIsSelectable = isPlayerSelectable(p);
+
+      return (
+        <ListItem
+          key={p.id}
+          onClick={() => playerIsSelectable ? onSelection(p.id) : null}
+          aria-disabled={!playerIsSelectable}
+          height={280 / players.length}
+          alignItems="center"
+          display="flex"
+          placeContent="center"
+          role="button"
+          transition="background 500ms"
+          _disabled={{
+            color: "whiteAlpha.500",
+            pointerEvents: "none"
+          }}
+          _hover={ playerIsSelectable ? {
+            background: "rgba(66, 153, 225, 0.6)",
+          } : {}}
+          sx={{
+            "&:first-of-type": {
+              borderRadius: "10px 10px 0px 0px",
+            },
+            "&:last-of-type": {
+              borderRadius: "0px 0px 10px 10px",
+            },
+            "&:not(:last-child)": {
+              borderBottom: "1px solid",
+              borderColor: "gray.800",
+            },
+          }}
+        >
+          <Text>{p.name}</Text>
+        </ListItem>
+      );
+    })}
   </List>
 );
 


### PR DESCRIPTION
## Summary

Previously there was no limiter when performing steal. You could steal 2 coins from any player whether they had 0, 1, or >2 coins. This work blocks the ability to steal coins from players with 0 coins and will only steal 1 coin if that is all the victim has.

## Changes

`usePlayerActions.ts` - Only steal the number of coins the victim has up to 2.
`Actions.tsx` - Provide functions to `PlayerSelect.tsx` for checking whether a player can be chosen for the selected action.
`PlayerSelect.tsx` - Shows all players and uses provided function for determining if a player can be selected. If a player cannot be selected, their name will show as disabled.
