### PR TITLE
Modal text updates and some modal restructuring

### DIFF
--- a/web/src/GameState/useCurrentGameState/hooks/useProcessChallenge.ts
+++ b/web/src/GameState/useCurrentGameState/hooks/useProcessChallenge.ts
@@ -1,5 +1,5 @@
 import { useDeck } from "@contexts/DeckContext";
-import type { Influence, IPlayer } from "@contexts/GameStateContext";
+import { Actions, Influence, IPlayer } from "@contexts/GameStateContext";
 import { usePlayers } from "@contexts/PlayersContext";
 import { ActionDetails } from "@utils/ActionUtils";
 import { getInfluenceFromAction } from "@utils/InfluenceUtils";
@@ -97,6 +97,7 @@ export default function useProcessChallenge(
         });
       }
     } else if (currentGameState.matches("challenge_block")) {
+      if (!performer) throw new Error("No perfromer found when processing challenge.");
       if (!blocker) throw new Error("No blocker found when processing challenge.");
       if (!challenger) throw new Error("No challenger found when processing challenge.");
 
@@ -164,11 +165,16 @@ export default function useProcessChallenge(
         victimName: loser.name,
       });
 
-      if (gameStateContext.challengeFailed)
+      if (gameStateContext.challengeFailed) {
+        actionToast({
+          blockerName: blocker.name,
+          performerName: performer.name,
+          variant: Actions.Block,
+        });
         sendGameStateEvent("CHALLENGE_BLOCK_FAILED", {
           nextPlayerTurnId: getNextPlayerTurnId(gameStateContext.playerTurnId),
         });
-      else sendGameStateEvent("COMPLETE");
+      } else sendGameStateEvent("COMPLETE");
     }
   }, [currentGameState.value, gameStateContext.challengeFailed]);
 }

--- a/web/src/components/Bold.tsx
+++ b/web/src/components/Bold.tsx
@@ -1,0 +1,8 @@
+import { Text, TextProps } from "@chakra-ui/react";
+import * as React from "react";
+
+const Bold: React.FC<TextProps> = ({ children, ...props }) => (
+  <Text as="span" fontWeight="bold" {...props}>{children}</Text>
+);
+
+export default Bold;

--- a/web/src/components/GameModalChooser/ModalChoosers/ActionModalChooser.tsx
+++ b/web/src/components/GameModalChooser/ModalChoosers/ActionModalChooser.tsx
@@ -6,6 +6,9 @@ import ActionProposedModal from "../../Modals/ActionProposedModal";
 import LoseInfluenceModal from "../../Modals/LoseInfluenceModal";
 import WaitingForActionModal from "../../Modals/WaitingForActionModal";
 import ExchangeModal from "@components/Modals/ExchangeModal";
+import Bold from "@components/Bold";
+import { Text } from "@chakra-ui/react";
+import { ActionDetails } from "@utils/ActionUtils";
 
 interface IActionModalChooserProps {
   action: Actions;
@@ -50,12 +53,19 @@ const ActionModalChooser: React.FC<IActionModalChooserProps> = ({
         }
       />
     ) : (
-      <WaitingForActionModal
-        messaging={[
-          `${performer.name} has chosen to ${action}.`,
-          `Waiting for ${performer.name} to choose which Influences to exchange.`,
-        ]}
-      />
+      <WaitingForActionModal>
+        <Text>
+          <Bold>{performer.name}</Bold>
+          {" has chosen to "}
+          <Bold color={ActionDetails[action].color}>{action}</Bold>
+          .
+        </Text>
+        <Text>
+          {"Waiting for "}
+          <Bold>{performer.name}</Bold>
+          {" to finish their selections."}
+        </Text>
+      </WaitingForActionModal>
     );
   }
   // Prompt victim to choose an influence to kill
@@ -96,12 +106,21 @@ const ActionModalChooser: React.FC<IActionModalChooserProps> = ({
           }
         />
       ) : (
-        <WaitingForActionModal
-          messaging={[
-            `${performer.name} has chosen to ${action} ${victim.name}.`,
-            `Waiting for ${victim.name} to choose an Influence to lose.`,
-          ]}
-        />
+        <WaitingForActionModal>
+          <Text>
+            <Bold>{performer.name}</Bold>
+            {" has chosen to "}
+            <Bold color={ActionDetails[action].color}>{action}</Bold>
+            &nbsp;
+            <Bold>{victim.name}</Bold>
+            .
+          </Text>
+          <Text>
+            {"Waiting for "}
+            <Bold>{victim.name}</Bold>
+            {" to choose an influence to lose."}
+          </Text>
+        </WaitingForActionModal>
       );
     }
 

--- a/web/src/components/GameModalChooser/ModalChoosers/ChallengerModalChooser.tsx
+++ b/web/src/components/GameModalChooser/ModalChoosers/ChallengerModalChooser.tsx
@@ -1,8 +1,10 @@
+import Bold from "@components/Bold";
 import ChallengedModal from "@components/Modals/ChallengedModal";
 import LoseInfluenceModal from "@components/Modals/LoseInfluenceModal";
 import WaitingForActionModal from "@components/Modals/WaitingForActionModal";
 import type { Actions, IGameState, Influence, IPlayer } from "@contexts/GameStateContext";
 import { getInfluenceFromAction, wasValidAction } from "@utils/InfluenceUtils";
+import { Text } from "@chakra-ui/react";
 import * as React from "react";
 
 interface IChallengerModalChooserProps {
@@ -73,13 +75,31 @@ const ChallengerModalChooser: React.FC<IChallengerModalChooserProps> = ({
     } else {
       // if current player is not the one choosing an influence to lose
       const success = challengeResult === "success";
+      const challengedPlayerName = blocker?.name ?? performer.name;
+
       return (
-        <WaitingForActionModal
-          messaging={[
-            `${challenger.name}'s challenge against ${performer.name} ${success ? "was successful" : "failed"}.`,
-            `Waiting for ${success ? performer.name : challenger.name} to choose an Influence to lose.`,
-          ]}
-        />
+        <WaitingForActionModal>
+          <Text>
+            <Bold>{challenger.name}</Bold>
+            {"'s challenge against "}
+            <Bold>{challengedPlayerName}</Bold>
+            &nbsp;
+            <Bold
+              textTransform="uppercase"
+              color={success ? "green.300" : "red.300"}
+            >
+              {success ? "succeeded" : "failed"}
+            </Bold>
+            .
+          </Text>
+          <Text>
+            {"Waiting for "}
+            <Bold>
+              {success ? challengedPlayerName : challenger.name}
+            </Bold>
+            {" to choose an Influence to lose."}
+          </Text>
+        </WaitingForActionModal>
       );
     }
   } else if (blocker && blockingInfluence) {

--- a/web/src/components/Modals/WaitingForActionModal.tsx
+++ b/web/src/components/Modals/WaitingForActionModal.tsx
@@ -1,20 +1,12 @@
 import * as React from "react";
-import { Center, Image, Text, VStack, useId } from "@chakra-ui/react";
+import { Center, Image, VStack } from "@chakra-ui/react";
 import WaitingGif from "@images/Waiting.gif";
 import BaseModal from "./BaseModal";
 
-interface IWaitingForActionModal {
-  messaging: Array<React.ReactElement | string>;
-}
-
-const WaitingForActionModal: React.FC<IWaitingForActionModal> = ({ messaging }) => (
+const WaitingForActionModal: React.FC = ({ children }) => (
   <BaseModal>
-    <VStack margin="10" spacing="6">
-      {messaging.map((m) => (
-        <Text key={useId()} fontSize="large" textAlign="center">
-          {m}
-        </Text>
-      ))}
+    <VStack margin="10" spacing="6" textAlign="center" fontSize="large">
+      {children}
       <Center>
         <Image src={WaitingGif} />
       </Center>

--- a/web/src/contexts/GameStateContext/types.ts
+++ b/web/src/contexts/GameStateContext/types.ts
@@ -12,7 +12,7 @@ export const enum Actions {
   Assassinate = "assassinate",
   Tax = "collect tax",
   Steal = "steal",
-  Exchange = "exchange Influences",
+  Exchange = "exchange influences",
   Income = "collect income",
   Aid = "collect foreign aid",
   Coup = "coup",

--- a/web/src/hooks/useActionToast.tsx
+++ b/web/src/hooks/useActionToast.tsx
@@ -1,8 +1,10 @@
 import React from "react";
 import { Box, Center, CloseButton, Text, useToast, useToken } from "@chakra-ui/react";
-import { AxeIcon, ChallengeIcon, CoinIcon, AssassinIcon } from "@icons";
+import { ChallengeIcon } from "@icons";
 import { Actions, Influence } from "@contexts/GameStateContext/types";
 import { InfluenceDetails } from "@utils/InfluenceUtils";
+import { ActionDetails } from "@utils/ActionUtils";
+import Bold from "@components/Bold";
 
 export interface IActionToastProps {
   variant: Actions | "Challenge";
@@ -21,6 +23,7 @@ const ActionToast: React.FC<IActionToastProps> = ({
 }) => {
   const { closeAll: closeAllToasts } = useToast();
   const iconSize = useToken("sizes", "40");
+  const ActionIcon = variant === "Challenge" ? ChallengeIcon : ActionDetails[variant].icon;
 
   return (
     <Box
@@ -35,138 +38,89 @@ const ActionToast: React.FC<IActionToastProps> = ({
     >
       <CloseButton marginLeft="auto" onClick={() => closeAllToasts()} />
       <Center>
-        {variant === Actions.Income && <CoinIcon width={iconSize} />}
-        {/* TODO: Needs Graphic */}
-        {variant === Actions.Coup && <AxeIcon width={iconSize} />}
-        {/* TODO: Needs Graphic */}
-        {variant === Actions.Tax && <CoinIcon width={iconSize} />}
-        {/* TODO: Needs Graphic */}
-        {variant === Actions.Aid && <CoinIcon width={iconSize} />}
-        {/* TODO: Needs Graphic */}
-        {variant === "Challenge" && <ChallengeIcon width={iconSize} />}
-        {/* TODO: Needs Graphic */}
-        {variant === Actions.Block && <CoinIcon width={iconSize} />}
-        {/* TODO: Needs Graphic */}
-        {variant === Actions.Steal && <CoinIcon width={iconSize} />}
-        {variant === Actions.Assassinate && <AssassinIcon width={iconSize} />}
-        {/* TODO: Needs Graphic */}
-        {variant === Actions.Exchange && <CoinIcon width={iconSize} />}
+        <ActionIcon width={iconSize} />
       </Center>
-      <Box fontSize="large">
+      <Text fontSize="large">
         {variant === Actions.Income && (
-          <Text>
-            <Text as="span" fontWeight="bold">
-              {performerName}
-            </Text>
+          <>
+            <Bold>{performerName}</Bold>
             {" took income which is only performed by mere peasants."}
-          </Text>
+          </>
         )}
         {variant === Actions.Tax && (
-          <Text>
-            <Text as="span" fontWeight="bold">
-              {performerName}
-            </Text>
+          <>
+            <Bold>{performerName}</Bold>
             {" must have royalty in their blood as they have collected tax from the peasants."}
-          </Text>
+          </>
         )}
         {variant === Actions.Aid && (
-          <Text>
-            <Text as="span" fontWeight="bold">
-              {performerName}
-            </Text>
+          <>
+            <Bold>{performerName}</Bold>
             {" has gotten away with foreign aid! A very generous group of Dukes indeed."}
-          </Text>
+          </>
         )}
         {variant === Actions.Block && (
-          <Text>
-            <Text as="span" fontWeight="bold">
-              {blockerName}
-            </Text>
+          <>
+            <Bold>{blockerName}</Bold>
             {" successfully blocked "}
-            <Text as="span" fontWeight="bold">
-              {performerName}
-            </Text>
-          </Text>
+            <Bold>{performerName}</Bold>
+          </>
         )}
         {variant === Actions.Coup && (
           <>
-            <Text>
-              <Text as="span" fontWeight="bold">
-                {performerName}
-              </Text>
-              {" coup'd "}
-              <Text as="span" fontWeight="bold">
-                {victimName}
-              </Text>
-              !
-            </Text>
-            <Text marginTop="3">
-              <Text as="span" fontWeight="bold">
-                {victimName}
-              </Text>
-              {" lost their "}
-              {/* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */}
-              <Text as="span" fontWeight="bold" color={InfluenceDetails[lostInfluence!].color}>
-                {lostInfluence}
-              </Text>
-              .
-            </Text>
+            <Bold>{performerName}</Bold>
+            {" coup'd "}
+            <Bold>{victimName}</Bold>
+            {" who lost their "}
+            {/* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */}
+            <Bold color={InfluenceDetails[lostInfluence!].color}>
+              {lostInfluence}
+            </Bold>
+            !
           </>
         )}
         {variant === Actions.Steal && (
-          <Text>
-            <Text as="span" fontWeight="bold">
-              {performerName}
-            </Text>
+          <>
+            <Bold>{performerName}</Bold>
             {" has stolen coin from "}
-            <Text as="span" fontWeight="bold">
-              {victimName}
-            </Text>
+            <Bold>{victimName}</Bold>
             !
-          </Text>
+          </>
         )}
         {variant === Actions.Assassinate && (
-          <Text>
-            <Text as="span" fontWeight="bold">
-              {performerName}
-            </Text>
+          <>
+            <Bold>{performerName}</Bold>
             {" has assassinated "}
-            <Text as="span" fontWeight="bold">
-              {victimName}
-            </Text>
+            <Bold>{victimName}</Bold>
             {lostInfluence && (
               <>
                 {" who lost their "}
-                <Text as="span" fontWeight="bold" color={InfluenceDetails[lostInfluence].color}>
+                <Bold color={InfluenceDetails[lostInfluence].color}>
                   {lostInfluence}
-                </Text>
+                </Bold>
               </>
             )}
             !
-          </Text>
+          </>
         )}
         {variant === Actions.Exchange && (
-          <Text>
-            <Text as="span" fontWeight="bold">
-              {performerName}
-            </Text>
+          <>
+            <Bold>{performerName}</Bold>
             {" exchanged their cards. No one likes double Contessas."}
-          </Text>
+          </>
         )}
         {variant === "Challenge" && (
-          <Text marginTop="3">
-            <Text as="span" fontWeight="bold">
-              {victimName}
-            </Text>
+          <>
+            <Bold display="inline-block" marginTop="3">{victimName}</Bold>
             {" lost their "}
             {/* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */}
-            <Text as="span" fontWeight="bold" color={InfluenceDetails[lostInfluence!].color}>
+            <Bold color={InfluenceDetails[lostInfluence!].color}>
               {lostInfluence}
-            </Text>
+            </Bold>
             .
-          </Text>
+          </>
         )}
-      </Box>
+      </Text>
     </Box>
   );
 };

--- a/web/src/hooks/useActionToast.tsx
+++ b/web/src/hooks/useActionToast.tsx
@@ -64,6 +64,7 @@ const ActionToast: React.FC<IActionToastProps> = ({
             <Bold>{blockerName}</Bold>
             {" successfully blocked "}
             <Bold>{performerName}</Bold>
+            .
           </>
         )}
         {variant === Actions.Coup && (

--- a/web/src/utils/ActionUtils.ts
+++ b/web/src/utils/ActionUtils.ts
@@ -1,17 +1,37 @@
+import type { ThemeTypings } from "@chakra-ui/react";
 import { Actions, Influence } from "@contexts/GameStateContext";
+import { AxeIcon, CoinIcon, AssassinIcon } from "@icons";
+import { InfluenceDetails } from "./InfluenceUtils";
 
 export interface IActionDetails {
   blockable: Readonly<Array<Influence> | null>;
   challengable: Readonly<boolean>;
+  color: Readonly<ThemeTypings["colors"]>;
+  icon: React.FC<React.SVGProps<SVGSVGElement>>;
 }
 
 export const ActionDetails: Record<Actions, IActionDetails> = {
-  [Actions.Aid]: { blockable: ["Duke"], challengable: false },
-  [Actions.Assassinate]: { blockable: ["Contessa"], challengable: true },
-  [Actions.Coup]: { blockable: null, challengable: false },
-  [Actions.Exchange]: { blockable: null, challengable: true },
-  [Actions.Income]: { blockable: null, challengable: false },
-  [Actions.Steal]: { blockable: ["Captain", "Ambassador"], challengable: true },
-  [Actions.Tax]: { blockable: null, challengable: true },
-  [Actions.Block]: { blockable: null, challengable: true },
+  [Actions.Aid]: { blockable: ["Duke"], challengable: false, color: "teal.300", icon: CoinIcon },
+  [Actions.Assassinate]: {
+    blockable: ["Contessa"],
+    challengable: true,
+    color: InfluenceDetails["Assassin"].color,
+    icon: AssassinIcon,
+  },
+  [Actions.Coup]: { blockable: null, challengable: false, color: "red.300", icon: AxeIcon },
+  [Actions.Exchange]: {
+    blockable: null,
+    challengable: true,
+    color: InfluenceDetails["Ambassador"].color,
+    icon: CoinIcon,
+  },
+  [Actions.Income]: { blockable: null, challengable: false, color: "teal.300", icon: CoinIcon },
+  [Actions.Steal]: {
+    blockable: ["Captain", "Ambassador"],
+    challengable: true,
+    color: InfluenceDetails["Captain"].color,
+    icon: CoinIcon,
+  },
+  [Actions.Tax]: { blockable: null, challengable: true, color: InfluenceDetails["Duke"].color, icon: CoinIcon },
+  [Actions.Block]: { blockable: null, challengable: true, color: "pink.300", icon: CoinIcon },
 };


### PR DESCRIPTION
## Summary

This work fixes the blocker name not showing up correctly in the waiting modal after a block. Included in this is some restructuring that allows for formatting of names and the action in the modal to be consistent with other places in the UI.

## Changes

`useProcessChallenge.ts` - Show block toast on failed challenge on block.
`Bold.tsx` - A simple, inline element that bolds the text.
`ActionModalChooser.tsx` & `ChallengerModalChooser.tsx` - Use Text elements and proper formatting instead of old string based prop.
`WaitingForActionModal.tsx` - Refactored to use children prop instead of messaging prop to allow for more customization of messaging.
`useActionToast.tsx` - Refactored to use new `Bold` component and get icon from `ActionDetails`.
`ActionUtils.ts` - Updated to include icon and color for each action.