### PR TITLE
Stop stealing from the dead and disable steal if no one to steal from

### DIFF
--- a/web/src/components/Actions/Actions.tsx
+++ b/web/src/components/Actions/Actions.tsx
@@ -44,7 +44,7 @@ const Actions: React.FC<IActionsProps> = ({ otherPlayers }) => {
     width: "324px",
   };
 
-  const validPlayersToStealFrom = (p: IPlayer): boolean => p.coins > 0;
+  const validPlayersToStealFrom = (p: IPlayer): boolean => p.coins > 0 && p.influences.some((i) => !i.isDead);
   const validPlayersToLoseAnInfluence = (p: IPlayer): boolean => p.influences.some((i) => !i.isDead);
 
   return (
@@ -73,6 +73,7 @@ const Actions: React.FC<IActionsProps> = ({ otherPlayers }) => {
                 });
             }
           }}
+          players={otherPlayers}
           coinCount={currentPlayer.coins}
           isTurn={isTurn}
           {...commonStyles}

--- a/web/src/components/Actions/components/ActionButtons.tsx
+++ b/web/src/components/Actions/components/ActionButtons.tsx
@@ -1,6 +1,6 @@
 import { Button, Wrap, WrapItem, ButtonProps, WrapProps } from "@chakra-ui/react";
 import * as React from "react";
-import { Actions } from "@contexts/GameStateContext";
+import { Actions, IPlayer } from "@contexts/GameStateContext";
 import { InfluenceDetails } from "@utils/InfluenceUtils";
 
 interface IWrappedButtonProps extends Omit<ButtonProps, "width"> {
@@ -11,14 +11,22 @@ interface IActionButtonsProps extends WrapProps {
   onAction: (action: Actions) => void;
   isTurn: boolean;
   coinCount: number;
+  players: Array<IPlayer>;
 }
 
 const ActionButtons: React.FC<IActionButtonsProps> = ({
   coinCount,
   onAction,
+  players,
   isTurn,
   ...props
 }) => {
+  const canSteal = React.useMemo(() => {
+    return players.some((player) => (
+      player.influences.some((influence) => !influence.isDead) && player.coins > 0
+    ));
+  }, [players]);
+
   const WrappedButton: React.FC<IWrappedButtonProps> = ({ action, children, disabled, ...buttonProps }) => (
     <WrapItem>
       <Button
@@ -44,7 +52,7 @@ const ActionButtons: React.FC<IActionButtonsProps> = ({
       <WrappedButton
         action={Actions.Steal}
         colorScheme={InfluenceDetails["Captain"].colorScheme}
-        disabled={coinCount >= 10}
+        disabled={coinCount >= 10 || !canSteal}
       >
         Steal
       </WrappedButton>


### PR DESCRIPTION
## Summary

Previously you could steal from players who were not alive. In addition, you could still choose to steal even if there were no options to steal. This work only allows stealing from players who are alive and disables the steal button if there's no one to steal from.

## Changes

`ActionButtons.tsx` - Takes in the list of other players and checks to see if anyone can be stolen from. If not, the steal button is disabled.
`Actions.tsx` - Pass other players to `ActionButtons` and add alive check to steal verification function.
