### PR TITLE
Add player turn indication

### DIFF
--- a/web/src/components/Modals/ExchangeModal.tsx
+++ b/web/src/components/Modals/ExchangeModal.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { BoxProps, Button, Divider, HStack, Text, VStack } from "@chakra-ui/react";
-import type { IPlayer, IPlayerInfluence } from "@contexts/GameStateContext/types";
+import type { IPlayer, IPlayerInfluence } from "@contexts/GameStateContext";
 import InfluenceCard from "../InfluenceCard";
 import BaseModal from "./BaseModal";
 import { useDeck } from "@contexts/DeckContext";

--- a/web/src/components/PlayerHand.tsx
+++ b/web/src/components/PlayerHand.tsx
@@ -1,4 +1,4 @@
-import { VStack, HStack, Text, useId } from "@chakra-ui/react";
+import { VStack, HStack, Text, useId, keyframes, TextProps } from "@chakra-ui/react";
 import * as React from "react";
 import type { IPlayer } from "@contexts/GameStateContext/types";
 import InfluenceCard from "./InfluenceCard";
@@ -6,26 +6,49 @@ import InfluenceCard from "./InfluenceCard";
 interface IPlayerHandProps {
   isCurrentPlayer?: boolean;
   player: IPlayer;
+  isTurn?: boolean;
 }
 
-const PlayerHand: React.FC<IPlayerHandProps> = ({ isCurrentPlayer, player }) => (
-  <VStack width={isCurrentPlayer ? "420px" : "325px"}>
-    <HStack justifyContent="space-between" width="100%">
-      <Text fontSize="lg">{player.name}</Text>
-      <Text fontSize="lg" color="gray.400">{`Coins: ${player.coins}`}</Text>
-    </HStack>
-    <HStack spacing={isCurrentPlayer ? "20px" : "10px"}>
-      {player.influences.map(({ type, isDead }) => (
-        <InfluenceCard
-          key={`${player.name}-${type}-${useId()}`}
-          influence={type}
-          faceUp={Boolean(isCurrentPlayer)}
-          isDead={isDead}
-          enlarge={isCurrentPlayer}
-        />
-      ))}
-    </HStack>
-  </VStack>
-);
+const nowYourTurnAnimation = keyframes({
+  "0%": {
+    transform: "scale(1)",
+  },
+  "50%": {
+    fontWeight: "bold",
+    transform: "scale(1.2)",
+  },
+  // eslint-disable-next-line sort-keys
+  "100%": {
+    transform: "scale(1)",
+  },
+});
+
+const PlayerHand: React.FC<IPlayerHandProps> = ({ isCurrentPlayer, isTurn, player }) => {
+  const playerNameProps: TextProps = isTurn ? {
+    animation: `${nowYourTurnAnimation} 1s`,
+    color: "pink.300",
+    fontWeight: "bold",
+  } : {};
+
+  return (
+    <VStack width={isCurrentPlayer ? "420px" : "325px"}>
+      <HStack justifyContent="space-between" width="100%">
+        <Text {...playerNameProps} fontSize="lg">{player.name}</Text>
+        <Text fontSize="lg" color="gray.400">{`Coins: ${player.coins}`}</Text>
+      </HStack>
+      <HStack spacing={isCurrentPlayer ? "20px" : "10px"}>
+        {player.influences.map(({ type, isDead }) => (
+          <InfluenceCard
+            key={`${player.name}-${type}-${useId()}`}
+            influence={type}
+            faceUp={Boolean(isCurrentPlayer)}
+            isDead={isDead}
+            enlarge={isCurrentPlayer}
+          />
+        ))}
+      </HStack>
+    </VStack>
+  );
+};
 
 export default PlayerHand;

--- a/web/src/pages/Game.tsx
+++ b/web/src/pages/Game.tsx
@@ -9,7 +9,7 @@ import GameHelpSidebar from "@components/GameHelpSidebar";
 import { HelpIcon } from "@icons";
 
 const Game: React.FC = () => {
-  const { currentPlayer } = useGameState();
+  const { currentPlayer, currentPlayerTurn } = useGameState();
   const { isOpen, onClose, onOpen } = useDisclosure();
   const { players } = usePlayers();
   const otherPlayers = players.filter((player) => player.id.localeCompare(currentPlayer.id) !== 0);
@@ -20,12 +20,12 @@ const Game: React.FC = () => {
         <Wrap justify="center" spacing="60px" maxWidth="90%" margin="auto">
           {otherPlayers.map((player) => (
             <WrapItem key={player.id}>
-              <PlayerHand player={player} />
+              <PlayerHand isTurn={currentPlayerTurn?.id === player.id} player={player} />
             </WrapItem>
           ))}
         </Wrap>
         <HStack bottom="20" position="absolute" spacing="60px" width="100%" justifyContent="center">
-          <PlayerHand player={currentPlayer} isCurrentPlayer />
+          <PlayerHand isTurn={currentPlayerTurn?.id === currentPlayer.id} player={currentPlayer} isCurrentPlayer />
           <Actions otherPlayers={otherPlayers} />
         </HStack>
       </Box>


### PR DESCRIPTION
## Summary

Adds some styling to the name of the player whose turn it is. Gives other players some insight in who to yell at to hurry up with their turn.

## Changes

`PlayerHand.tsx` - Takes an `isTurn` prop and adds animation/styling when it is that player's turn.
`Game.tsx` - Pass `isTurn` prop
